### PR TITLE
feat: simplify batch table interfaces and add RemoveField

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Auto-generated from all feature plans. Last updated: 2025-11-29
 - N/A (storage-agnostic library) (001-batch-table-interfaces)
 - Go 1.25+ (matching existing project) + Standard library only (encoding/json for parsing, strings/fmt for encoding). No new external dependencies required. (012-filter-pushdown)
 - N/A (pure transformation library) (012-filter-pushdown)
+- Go 1.25+ + Apache Arrow Go v18 (`github.com/apache/arrow-go/v18`), gRPC (013-batch-table-signature)
 
 ## Project Structure
 
@@ -76,9 +77,9 @@ go work sync
 - No silent failures - errors must be handled explicitly
 
 ## Recent Changes
+- 013-batch-table-signature: Added Go 1.25+ + Apache Arrow Go v18 (`github.com/apache/arrow-go/v18`), gRPC
 - 012-filter-pushdown: Added Go 1.25+ (matching existing project) + Standard library only (encoding/json for parsing, strings/fmt for encoding). No new external dependencies required.
 - 001-batch-table-interfaces: Added Go 1.25+ + Apache Arrow Go v18, gRPC, msgpack-go
-- 006-returning-optimization: Added Go 1.25+ + Arrow-Go v18, gRPC, msgpack-go
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/catalog/dynamic.go
+++ b/catalog/dynamic.go
@@ -145,6 +145,12 @@ type RenameFieldOptions struct {
 	IgnoreNotFound bool
 }
 
+// RemoveFieldOptions configures field removal from struct columns.
+type RemoveFieldOptions struct {
+	// IgnoreNotFound suppresses error if table or column doesn't exist.
+	IgnoreNotFound bool
+}
+
 // CatalogVersion contains the version information for a catalog.
 type CatalogVersion struct {
 	// Version is the current version number of the catalog.
@@ -251,4 +257,9 @@ type DynamicTable interface {
 	// The columnPath is the path to the field (e.g., ["col", "nested", "field"]).
 	// Returns ErrNotFound if column path doesn't exist and IgnoreNotFound is false.
 	RenameField(ctx context.Context, columnPath []string, newName string, opts RenameFieldOptions) error
+
+	// RemoveField removes a field from a struct-typed column.
+	// The columnPath is the path to the field (e.g., ["col", "nested", "field"]).
+	// Returns ErrNotFound if column path doesn't exist and IfFieldExists is false.
+	RemoveField(ctx context.Context, columnPath []string, opts RemoveFieldOptions) error
 }

--- a/catalog/types.go
+++ b/catalog/types.go
@@ -2,10 +2,16 @@ package catalog
 
 import (
 	"context"
+	"errors"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 )
+
+// ErrNullRowID is returned when a null rowid value is encountered in UPDATE or DELETE operations.
+// Implementations of UpdatableBatchTable and DeletableBatchTable MUST return this error
+// when they encounter null values in the rowid column of the input Record.
+var ErrNullRowID = errors.New("null rowid value not allowed")
 
 // ScanOptions provides options for table scans.
 type ScanOptions struct {

--- a/examples/ddl/main.go
+++ b/examples/ddl/main.go
@@ -628,3 +628,16 @@ func (t *DDLTable) RenameField(_ context.Context, columnPath []string, newName s
 	fmt.Printf("[DDLTable:%s] RenameField called: %v -> %s (simplified)\n", t.name, columnPath, newName)
 	return nil
 }
+
+// RemoveField implements catalog.DynamicTable.
+func (t *DDLTable) RemoveField(_ context.Context, columnPath []string, opts catalog.RemoveFieldOptions) error {
+	// Simplified implementation - real implementation would handle nested struct fields
+	if len(columnPath) == 0 {
+		if opts.IgnoreNotFound {
+			return nil
+		}
+		return catalog.ErrNotFound
+	}
+	fmt.Printf("[DDLTable:%s] RemoveField called: %v (simplified)\n", t.name, columnPath)
+	return nil
+}

--- a/examples/dml/main.go
+++ b/examples/dml/main.go
@@ -216,9 +216,10 @@ func (m *InMemoryTransactionManager) GetTransactionStatus(_ context.Context, txI
 // and catalog.DeletableTable interfaces.
 //
 // Alternative: You can implement catalog.UpdatableBatchTable and catalog.DeletableBatchTable
-// instead (or in addition). The batch interfaces receive rowid embedded in the RecordReader
-// rather than as a separate []int64 slice. Use catalog.FindRowIDColumn(rows.Schema())
-// to locate the rowid column. Batch interfaces are preferred when both are implemented.
+// instead (or in addition). The batch interfaces receive a single arrow.RecordBatch containing
+// all data including the rowid column, rather than a separate []int64 slice for rowids.
+// Use catalog.FindRowIDColumn(rows.Schema()) to locate the rowid column.
+// Batch interfaces are preferred when both are implemented.
 type UsersTable struct {
 	schema    *arrow.Schema
 	alloc     memory.Allocator

--- a/flight/doaction.go
+++ b/flight/doaction.go
@@ -69,6 +69,8 @@ func (s *Server) DoAction(action *flight.Action, stream flight.FlightService_DoA
 		return s.handleAddFieldAction(ctx, action, stream)
 	case "rename_field":
 		return s.handleRenameFieldAction(ctx, action, stream)
+	case "remove_field":
+		return s.handleRemoveFieldAction(ctx, action, stream)
 
 	// Catalog version action
 	case "catalog_version":

--- a/specs/013-batch-table-signature/checklists/requirements.md
+++ b/specs/013-batch-table-signature/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Simplify Batch Table Interface Signatures
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- Note: While the spec mentions Go types like `arrow.Record`, these are part of the interface contract definition (what the method accepts), not implementation details (how it's built)

--- a/specs/013-batch-table-signature/contracts/interfaces.go
+++ b/specs/013-batch-table-signature/contracts/interfaces.go
@@ -1,0 +1,34 @@
+// Package contracts defines the new interface signatures for batch table operations.
+// This file is for documentation purposes - actual implementation is in catalog/table.go.
+package contracts
+
+import (
+	"context"
+
+	"github.com/apache/arrow-go/v18/arrow"
+
+	"github.com/hugr-lab/airport-go/catalog"
+)
+
+// UpdatableBatchTable defines the new Update signature with arrow.RecordBatch.
+// This replaces the previous signature that used array.RecordReader.
+type UpdatableBatchTable interface {
+	catalog.Table
+
+	// Update modifies existing rows using data from the RecordBatch.
+	// The rows RecordBatch contains both the rowid column and new column values.
+	// Implementations MUST return an error if any rowid value is null.
+	// Caller MUST call rows.Release() after Update returns.
+	Update(ctx context.Context, rows arrow.RecordBatch, opts *catalog.DMLOptions) (*catalog.DMLResult, error)
+}
+
+// DeletableBatchTable defines the new Delete signature with arrow.RecordBatch.
+// This replaces the previous signature that used array.RecordReader.
+type DeletableBatchTable interface {
+	catalog.Table
+
+	// Delete removes rows identified by rowid values in the RecordBatch.
+	// Implementations MUST return an error if any rowid value is null.
+	// Caller MUST call rows.Release() after Delete returns.
+	Delete(ctx context.Context, rows arrow.RecordBatch, opts *catalog.DMLOptions) (*catalog.DMLResult, error)
+}

--- a/specs/013-batch-table-signature/data-model.md
+++ b/specs/013-batch-table-signature/data-model.md
@@ -1,0 +1,139 @@
+# Data Model: Batch Table Interface Signatures
+
+**Feature**: 013-batch-table-signature
+**Date**: 2025-12-30
+
+## Interface Definitions
+
+### UpdatableBatchTable (Updated)
+
+```go
+// UpdatableBatchTable extends Table with batch-oriented UPDATE capability.
+// The Update method receives the complete input Record including the rowid column.
+// Implementations extract rowid values from the rowid column in the Record.
+// This interface is preferred over UpdatableTable when both are implemented.
+// Implementations MUST be goroutine-safe.
+type UpdatableBatchTable interface {
+    Table
+
+    // Update modifies existing rows using data from the Record.
+    // The rows Record contains both the rowid column (identifying rows to update)
+    // and the new column values. Implementations MUST extract rowid values from
+    // the rowid column (identified by name "rowid" or metadata key "is_rowid").
+    // Use FindRowIDColumn(rows.Schema()) to locate the rowid column.
+    // Implementations MUST return an error if any rowid value is null.
+    // Row order in Record determines update order.
+    // The opts parameter provides options including RETURNING clause information:
+    //   - opts.Returning: true if RETURNING clause was specified
+    //   - opts.ReturningColumns: column names to include in RETURNING results
+    // Returns DMLResult with affected row count and optional returning data.
+    // Context may contain transaction ID for coordinated operations.
+    // Caller MUST call rows.Release() after Update returns.
+    Update(ctx context.Context, rows arrow.Record, opts *DMLOptions) (*DMLResult, error)
+}
+```
+
+### DeletableBatchTable (Updated)
+
+```go
+// DeletableBatchTable extends Table with batch-oriented DELETE capability.
+// The Delete method receives a Record containing the rowid column.
+// Implementations extract rowid values from the rowid column in the Record.
+// This interface is preferred over DeletableTable when both are implemented.
+// Implementations MUST be goroutine-safe.
+type DeletableBatchTable interface {
+    Table
+
+    // Delete removes rows identified by rowid values in the Record.
+    // The rows Record contains the rowid column (identified by name "rowid"
+    // or metadata key "is_rowid") that identifies rows to delete.
+    // Use FindRowIDColumn(rows.Schema()) to locate the rowid column.
+    // Implementations MUST return an error if any rowid value is null.
+    // The opts parameter provides options including RETURNING clause information:
+    //   - opts.Returning: true if RETURNING clause was specified
+    //   - opts.ReturningColumns: column names to include in RETURNING results
+    // Returns DMLResult with affected row count and optional returning data.
+    // Context may contain transaction ID for coordinated operations.
+    // Caller MUST call rows.Release() after Delete returns.
+    Delete(ctx context.Context, rows arrow.Record, opts *DMLOptions) (*DMLResult, error)
+}
+```
+
+## Key Types (Unchanged)
+
+### DMLOptions
+
+```go
+// DMLOptions configures DML operation behavior.
+type DMLOptions struct {
+    // Returning indicates if RETURNING clause was specified.
+    Returning bool
+
+    // ReturningColumns lists column names to include in RETURNING results.
+    // Empty means all columns.
+    ReturningColumns []string
+}
+```
+
+### DMLResult
+
+```go
+// DMLResult contains the result of a DML operation.
+type DMLResult struct {
+    // AffectedRows is the number of rows affected by the operation.
+    AffectedRows int64
+
+    // ReturningData contains data for RETURNING clause if requested.
+    // May be nil if RETURNING was not requested.
+    ReturningData array.RecordReader
+}
+```
+
+## Type Relationships
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         Table                                │
+│  - Name() string                                            │
+│  - Comment() string                                         │
+│  - ArrowSchema(columns []string) *arrow.Schema              │
+│  - Scan(ctx, opts) (array.RecordReader, error)              │
+└─────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ extends
+        ┌─────────────────────┴─────────────────────┐
+        │                                           │
+┌───────┴───────────────────┐     ┌─────────────────┴───────────┐
+│   UpdatableBatchTable     │     │   DeletableBatchTable       │
+│                           │     │                             │
+│ Update(ctx, rows Record,  │     │ Delete(ctx, rows Record,    │
+│        opts) (*Result, e) │     │        opts) (*Result, e)   │
+└───────────────────────────┘     └─────────────────────────────┘
+        │                                           │
+        │ preferred over                            │ preferred over
+        ▼                                           ▼
+┌───────────────────────────┐     ┌─────────────────────────────┐
+│   UpdatableTable (legacy) │     │   DeletableTable (legacy)   │
+│                           │     │                             │
+│ Update(ctx, rowIDs []int64│     │ Delete(ctx, rowIDs []int64, │
+│   rows RecordReader, opts)│     │        opts) (*Result, e)   │
+└───────────────────────────┘     └─────────────────────────────┘
+```
+
+## Signature Change Summary
+
+| Interface | Method | Before | After |
+|-----------|--------|--------|-------|
+| UpdatableBatchTable | Update | `rows array.RecordReader` | `rows arrow.Record` |
+| DeletableBatchTable | Delete | `rows array.RecordReader` | `rows arrow.Record` |
+
+## Error Handling
+
+New error condition added:
+
+```go
+// ErrNullRowID is returned when a null rowid value is encountered.
+var ErrNullRowID = errors.New("null rowid value not allowed")
+```
+
+When implementations encounter a null rowid in the Record, they MUST return an error immediately without processing any rows.

--- a/specs/013-batch-table-signature/plan.md
+++ b/specs/013-batch-table-signature/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Simplify Batch Table Interface Signatures
+
+**Branch**: `013-batch-table-signature` | **Date**: 2025-12-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/013-batch-table-signature/spec.md`
+
+## Summary
+
+Change `UpdatableBatchTable.Update` and `DeletableBatchTable.Delete` method signatures from accepting `array.RecordReader` to `arrow.Record`. This simplifies both the interface (users access data directly without iterator semantics) and the handler implementation (no need to wrap single batches in RecordReader).
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: Apache Arrow Go v18 (`github.com/apache/arrow-go/v18`), gRPC
+**Storage**: N/A (storage-agnostic library)
+**Testing**: Go test with race detector, integration tests with DuckDB Airport extension
+**Target Platform**: Cross-platform (Linux, macOS, Windows)
+**Project Type**: Go library (single module with workspace for tests/examples)
+**Performance Goals**: Zero-copy where possible, streaming for large datasets
+**Constraints**: Backward compatibility with legacy interfaces (`UpdatableTable`, `DeletableTable`)
+**Scale/Scope**: Library change affecting 2 interfaces, 2 handlers, integration tests, and examples
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Code Quality | ✅ PASS | Change follows idiomatic Go patterns; simplifies API by removing unnecessary abstraction |
+| II. Testing Standards | ✅ PASS | Integration tests exist and will be updated; no new untested code paths |
+| III. User Experience Consistency | ✅ PASS | Improves API clarity; backward compatible via legacy interfaces |
+| IV. Performance Requirements | ✅ PASS | Removes RecordReader construction overhead; zero-copy improvement |
+
+**Gate Result**: PASS - No violations. Proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-batch-table-signature/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (interface contracts)
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+# Go library structure
+catalog/
+├── table.go             # Interface definitions (UpdatableBatchTable, DeletableBatchTable)
+├── helpers.go           # Helper functions (FindRowIDColumn)
+└── types.go             # DMLOptions, DMLResult types
+
+flight/
+├── doexchange_dml.go    # Handler implementations (handleDoExchangeUpdate, handleDoExchangeDelete)
+└── dml_types.go         # DML-related types
+
+examples/
+└── dml/main.go          # DML example (demonstrates both interface styles)
+
+tests/
+└── integration/
+    └── dml_batch_test.go # Batch interface integration tests
+
+docs/
+└── api-guide.md         # API documentation
+```
+
+**Structure Decision**: Existing Go library structure. Changes affect `catalog/table.go` (interfaces), `flight/doexchange_dml.go` (handlers), `tests/integration/dml_batch_test.go`, `examples/dml/main.go`, and `docs/api-guide.md`.
+
+## Complexity Tracking
+
+> No violations - simplification reduces complexity.

--- a/specs/013-batch-table-signature/quickstart.md
+++ b/specs/013-batch-table-signature/quickstart.md
@@ -1,0 +1,133 @@
+# Quickstart: Batch Table Interface Migration
+
+**Feature**: 013-batch-table-signature
+**Date**: 2025-12-30
+
+## Overview
+
+This guide shows how to migrate from the old `array.RecordReader` signatures to the new `arrow.Record` signatures for `UpdatableBatchTable` and `DeletableBatchTable`.
+
+## Before (Old Signature)
+
+```go
+// UpdatableBatchTable with RecordReader
+func (t *MyTable) Update(ctx context.Context, rows array.RecordReader, opts *catalog.DMLOptions) (*catalog.DMLResult, error) {
+    // Had to call rows.Next() and handle iterator semantics
+    for rows.Next() {
+        batch := rows.RecordBatch()
+        // Process batch...
+    }
+    if err := rows.Err(); err != nil {
+        return nil, err
+    }
+    return &catalog.DMLResult{AffectedRows: count}, nil
+}
+
+// DeletableBatchTable with RecordReader
+func (t *MyTable) Delete(ctx context.Context, rows array.RecordReader, opts *catalog.DMLOptions) (*catalog.DMLResult, error) {
+    for rows.Next() {
+        batch := rows.RecordBatch()
+        // Process batch...
+    }
+    // ...
+}
+```
+
+## After (New Signature)
+
+```go
+// UpdatableBatchTable with Record - simpler!
+func (t *MyTable) Update(ctx context.Context, rows arrow.Record, opts *catalog.DMLOptions) (*catalog.DMLResult, error) {
+    // Direct access to the record - no iterator needed
+    schema := rows.Schema()
+
+    // Find rowid column
+    rowidColIdx := catalog.FindRowIDColumn(schema)
+    if rowidColIdx == -1 {
+        return nil, errors.New("rowid column not found")
+    }
+
+    // Check for null rowids (required by spec)
+    rowidCol := rows.Column(rowidColIdx)
+    if rowidCol.NullN() > 0 {
+        return nil, catalog.ErrNullRowID
+    }
+
+    // Process rows directly
+    for i := 0; i < int(rows.NumRows()); i++ {
+        rowid := rows.Column(rowidColIdx).(*array.Int64).Value(i)
+        // Update row with rowid...
+    }
+
+    return &catalog.DMLResult{AffectedRows: rows.NumRows()}, nil
+}
+
+// DeletableBatchTable with Record - simpler!
+func (t *MyTable) Delete(ctx context.Context, rows arrow.Record, opts *catalog.DMLOptions) (*catalog.DMLResult, error) {
+    // Find rowid column
+    rowidColIdx := catalog.FindRowIDColumn(rows.Schema())
+    if rowidColIdx == -1 {
+        rowidColIdx = 0 // Default to first column for DELETE
+    }
+
+    // Check for null rowids
+    rowidCol := rows.Column(rowidColIdx)
+    if rowidCol.NullN() > 0 {
+        return nil, catalog.ErrNullRowID
+    }
+
+    // Collect rowids to delete
+    rowidArr := rowidCol.(*array.Int64)
+    for i := 0; i < int(rows.NumRows()); i++ {
+        rowid := rowidArr.Value(i)
+        // Delete row with rowid...
+    }
+
+    return &catalog.DMLResult{AffectedRows: rows.NumRows()}, nil
+}
+```
+
+## Key Differences
+
+| Aspect | Old (RecordReader) | New (Record) |
+|--------|-------------------|--------------|
+| Data access | Iterator (`Next()`) | Direct access |
+| Batch handling | Loop over batches | Single batch |
+| Schema access | `rows.Schema()` | `rows.Schema()` (same) |
+| Column access | `batch.Column(i)` | `rows.Column(i)` |
+| Row count | Per-batch iteration | `rows.NumRows()` |
+| Error checking | `rows.Err()` at end | Not needed |
+
+## Migration Steps
+
+1. **Update method signature**: Change `rows array.RecordReader` to `rows arrow.Record`
+
+2. **Remove iterator loop**: Replace `for rows.Next() { batch := rows.RecordBatch(); ... }` with direct access to `rows`
+
+3. **Remove error check**: Remove `rows.Err()` check (not needed for Record)
+
+4. **Add null rowid check**: Add check for null rowids and return `catalog.ErrNullRowID`
+
+5. **Update imports**: Ensure `github.com/apache/arrow-go/v18/arrow` is imported
+
+## Memory Management
+
+Memory management remains the same:
+- Caller (handler) retains the Record before passing
+- Your implementation processes the Record
+- Caller releases the Record after your method returns
+
+You do NOT need to call `rows.Release()` in your implementation.
+
+## Testing
+
+Your integration tests should continue to work. If you have unit tests that mock the interface, update them to pass `arrow.Record` instead of `array.RecordReader`.
+
+```go
+// Before
+reader, _ := array.NewRecordReader(schema, []arrow.RecordBatch{batch})
+result, err := table.Update(ctx, reader, opts)
+
+// After
+result, err := table.Update(ctx, batch, opts)
+```

--- a/specs/013-batch-table-signature/research.md
+++ b/specs/013-batch-table-signature/research.md
@@ -1,0 +1,108 @@
+# Research: Simplify Batch Table Interface Signatures
+
+**Feature**: 013-batch-table-signature
+**Date**: 2025-12-30
+
+## Overview
+
+This research document analyzes the proposed change from `array.RecordReader` to `arrow.Record` in the batch table interfaces.
+
+## Research Topics
+
+### 1. Arrow Record vs RecordReader Semantics
+
+**Decision**: Use `arrow.Record` directly instead of `array.RecordReader`
+
+**Rationale**:
+- `array.RecordReader` is an iterator interface with `Next()` method for streaming multiple batches
+- `arrow.Record` (alias for `arrow.RecordBatch`) represents a single batch of columnar data
+- Current handler implementation (`newUpdateProcessor`, `newDeleteProcessor`) always creates a RecordReader from a single batch:
+  ```go
+  batchReader, err := array.NewRecordReader(batch.Schema(), []arrow.RecordBatch{batch})
+  ```
+- This wrapping adds unnecessary overhead and complexity
+- Passing `arrow.Record` directly simplifies both the interface and implementation
+
+**Alternatives Considered**:
+1. **Keep RecordReader**: Rejected - adds complexity for no benefit since handlers always process single batches
+2. **Use `[]arrow.Record` slice**: Rejected - handlers receive one batch at a time from the stream; slice would require buffering
+3. **Use `arrow.RecordBatch` type directly**: `arrow.Record` is the same type (alias) and is more commonly used in Go Arrow APIs
+
+### 2. Memory Management
+
+**Decision**: Caller releases the Record after method returns (same pattern as current RecordReader)
+
+**Rationale**:
+- Arrow Go uses reference counting for memory management
+- The handler already retains/releases batches correctly
+- No change to memory management pattern is needed
+
+**Key Points**:
+- Handler calls `record.Retain()` before passing to method
+- Table implementation processes the record
+- Handler calls `record.Release()` after method returns
+- Same pattern used for INSERT operations
+
+### 3. Null RowID Handling
+
+**Decision**: Return error immediately on first null rowid (per clarification session)
+
+**Rationale**:
+- Null rowids indicate corrupted or invalid data from DuckDB protocol layer
+- Failing fast prevents partial updates/deletes with undefined behavior
+- Consistent with strict error handling principle from constitution
+
+**Implementation**:
+- Add null check when extracting rowid values from the Record
+- Return typed error with clear message
+
+### 4. Backward Compatibility
+
+**Decision**: Legacy interfaces remain unchanged
+
+**Rationale**:
+- `UpdatableTable` with `Update(ctx, rowIDs []int64, rows RecordReader)` continues to work
+- `DeletableTable` with `Delete(ctx, rowIDs []int64)` continues to work
+- Handler strategy pattern (`newUpdateProcessor`, `newDeleteProcessor`) already handles interface selection
+- Users can migrate at their own pace
+
+### 5. Handler Simplification
+
+**Current Implementation** (flight/doexchange_dml.go:809-822):
+```go
+if batchTable, ok := table.(catalog.UpdatableBatchTable); ok {
+    return func(ctx context.Context, batch arrow.RecordBatch, opts *catalog.DMLOptions) (*catalog.DMLResult, error) {
+        batchReader, err := array.NewRecordReader(batch.Schema(), []arrow.RecordBatch{batch})
+        if err != nil {
+            return nil, err
+        }
+        // ... call batchTable.Update(txCtx, batchReader, opts)
+    }, true
+}
+```
+
+**New Implementation**:
+```go
+if batchTable, ok := table.(catalog.UpdatableBatchTable); ok {
+    return func(ctx context.Context, batch arrow.RecordBatch, opts *catalog.DMLOptions) (*catalog.DMLResult, error) {
+        // ... call batchTable.Update(txCtx, batch, opts) directly
+    }, true
+}
+```
+
+**Benefits**:
+- Removes RecordReader construction (3 lines of boilerplate per handler)
+- Removes potential error handling for RecordReader creation
+- Clearer code intent
+
+## Conclusions
+
+No unknowns or blockers identified. The change is straightforward:
+
+1. **Interface change**: `array.RecordReader` → `arrow.Record` in method signatures
+2. **Handler simplification**: Remove RecordReader wrapping
+3. **Test updates**: Update table implementations in tests to use new signature
+4. **Example updates**: Update DML example to demonstrate new signature
+5. **Doc updates**: Update api-guide.md with new signature documentation
+
+All research complete. Proceed to Phase 1: Design & Contracts.

--- a/specs/013-batch-table-signature/spec.md
+++ b/specs/013-batch-table-signature/spec.md
@@ -1,0 +1,144 @@
+# Feature Specification: Simplify Batch Table Interface Signatures
+
+**Feature Branch**: `013-batch-table-signature`
+**Created**: 2025-12-30
+**Status**: Draft
+**Input**: User description: "Change Update and Delete method signatures in UpdatableBatchTable and DeletableBatchTable interfaces to accept arrow.Record instead of arrow.RecordReader. The RecordReader was being built from a single record in handlers, so RecordBatch simplifies both the interface and handler implementation."
+
+## Clarifications
+
+### Session 2025-12-30
+
+- Q: What happens when rowid column contains null values? → A: Return error immediately on first null rowid.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Simplified Update Method Signature (Priority: P1)
+
+As a library developer implementing UpdatableBatchTable, I want the Update method to receive an arrow.Record directly instead of a RecordReader, so I can access the data without calling Next() and without needing to handle iterator semantics.
+
+**Why this priority**: This is the core simplification. Since handlers build a RecordReader from a single batch anyway, passing the batch directly removes unnecessary abstraction and simplifies implementation code.
+
+**Independent Test**: Can be fully tested by implementing a table with the new Update signature and executing UPDATE SQL via DuckDB. Delivers simpler implementation pattern for table developers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a table implementing UpdatableBatchTable with the new signature, **When** an UPDATE SQL is executed via DuckDB Airport, **Then** the Update method receives the arrow.Record directly containing both rowid column and data columns.
+
+2. **Given** a table implementing UpdatableBatchTable with the new signature, **When** the Update method is called, **Then** the implementation can access rowid and data columns directly from the Record without calling Next().
+
+3. **Given** a table implementing UpdatableBatchTable with RETURNING clause, **When** Update completes, **Then** RETURNING data is properly sent back to the client.
+
+---
+
+### User Story 2 - Simplified Delete Method Signature (Priority: P1)
+
+As a library developer implementing DeletableBatchTable, I want the Delete method to receive an arrow.Record directly instead of a RecordReader, so I can access rowid values without handling iterator semantics.
+
+**Why this priority**: Provides consistency with the Update signature change and simplifies Delete implementations.
+
+**Independent Test**: Can be fully tested by implementing a table with the new Delete signature and executing DELETE SQL via DuckDB. Delivers simpler implementation pattern for table developers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a table implementing DeletableBatchTable with the new signature, **When** a DELETE SQL is executed via DuckDB Airport, **Then** the Delete method receives the arrow.Record directly containing the rowid column.
+
+2. **Given** a table implementing DeletableBatchTable with the new signature, **When** the Delete method is called, **Then** the implementation can extract rowid values directly from the Record.
+
+3. **Given** a table implementing DeletableBatchTable with RETURNING clause, **When** Delete completes, **Then** RETURNING data is properly sent back to the client.
+
+---
+
+### User Story 3 - Simplified Handler Implementation (Priority: P2)
+
+As a library maintainer, I want the handleDoExchangeUpdate and handleDoExchangeDelete handlers to pass the Record directly to table methods instead of wrapping it in a RecordReader, so the handler code is simpler and more efficient.
+
+**Why this priority**: This is the internal refactoring that enables the interface change. Removing the RecordReader construction simplifies handler logic.
+
+**Independent Test**: Can be validated by reviewing handler code and ensuring UPDATE/DELETE operations work correctly through integration tests.
+
+**Acceptance Scenarios**:
+
+1. **Given** the refactored handleDoExchangeUpdate handler, **When** it receives update data from the Flight stream, **Then** it passes the Record directly to the table's Update method without creating a RecordReader wrapper.
+
+2. **Given** the refactored handleDoExchangeDelete handler, **When** it receives delete data from the Flight stream, **Then** it passes the Record directly to the table's Delete method without creating a RecordReader wrapper.
+
+---
+
+### User Story 4 - Updated Examples and Documentation (Priority: P3)
+
+As a library user, I want the examples and documentation updated to reflect the new method signatures, so I can correctly implement my custom tables.
+
+**Why this priority**: Supporting material for adoption. Documentation must match the actual API.
+
+**Independent Test**: Can be validated by reviewing documentation and running examples successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated documentation, **When** a developer reads the API guide, **Then** they see the correct Record signatures for UpdatableBatchTable and DeletableBatchTable.
+
+2. **Given** the updated examples, **When** a developer runs the DML example, **Then** they see correct usage of the Record-based interfaces.
+
+---
+
+### Edge Cases
+
+- What happens when a Record contains no rowid column? The server should return an appropriate error.
+- What happens when rowid column contains null values? The method MUST return an error immediately upon encountering the first null rowid value.
+- What happens when the Record is empty (zero rows)? The operation should succeed with zero affected rows.
+- What happens when memory needs to be managed? Caller is responsible for releasing the Record after the method returns.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `UpdatableBatchTable.Update` method signature MUST be: `Update(ctx context.Context, rows arrow.Record, opts *DMLOptions) (*DMLResult, error)` where rows is an arrow.Record containing rowid column and data columns.
+
+- **FR-002**: The `DeletableBatchTable.Delete` method signature MUST be: `Delete(ctx context.Context, rows arrow.Record, opts *DMLOptions) (*DMLResult, error)` where rows is an arrow.Record containing the rowid column.
+
+- **FR-003**: The `handleDoExchangeUpdate` handler MUST be refactored to pass the Record directly to the Update method instead of wrapping it in a RecordReader.
+
+- **FR-004**: The `handleDoExchangeDelete` handler MUST be refactored to pass the Record directly to the Delete method instead of wrapping it in a RecordReader.
+
+- **FR-005**: All existing integration tests MUST be updated to use the new method signatures.
+
+- **FR-006**: The DML example MUST be updated to demonstrate the new Record-based signatures.
+
+- **FR-007**: Documentation (api-guide.md, README) MUST be updated to reflect the new method signatures.
+
+- **FR-008**: The rowid column in the Record MUST be identifiable by the column name "rowid" or by the presence of `is_rowid` metadata with value "true".
+
+- **FR-009**: Memory management responsibility MUST be documented: caller releases the Record after method returns.
+
+- **FR-010**: RETURNING clause functionality MUST work correctly with the new signatures.
+
+- **FR-011**: Update and Delete methods MUST return an error immediately upon encountering a null rowid value in the Record.
+
+### Key Entities
+
+- **UpdatableBatchTable**: Interface with batch-oriented Update capability. The Update method receives data as arrow.Record.
+
+- **DeletableBatchTable**: Interface with batch-oriented Delete capability. The Delete method receives rowids as arrow.Record.
+
+- **arrow.Record**: Apache Arrow Record (RecordBatch) containing columnar data. Used directly instead of RecordReader iterator.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All integration tests pass with the new method signatures.
+
+- **SC-002**: The DML example runs successfully demonstrating Record-based interface usage.
+
+- **SC-003**: Library users can implement UPDATE/DELETE functionality by receiving arrow.Record directly without handling RecordReader iteration.
+
+- **SC-004**: Handler code (handleDoExchangeUpdate, handleDoExchangeDelete) is simplified by removing RecordReader construction logic.
+
+- **SC-005**: Documentation and API guide correctly describe the new method signatures.
+
+## Assumptions
+
+- The change from RecordReader to Record is safe because handlers were always building RecordReader from a single batch.
+- The existing helper function FindRowIDColumn works with arrow.Schema from Record.
+- The legacy interfaces (UpdatableTable, DeletableTable with rowIDs []int64) remain unchanged for backward compatibility.
+- Memory management follows the same pattern: caller releases the Record after method returns.

--- a/specs/013-batch-table-signature/tasks.md
+++ b/specs/013-batch-table-signature/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: Simplify Batch Table Interface Signatures
+
+**Input**: Design documents from `/specs/013-batch-table-signature/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Go library**: `catalog/`, `flight/`, `examples/`, `tests/`, `docs/` at repository root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No setup required - existing project structure
+
+**Note**: This feature modifies an existing Go library. No project initialization needed.
+
+---
+
+## Phase 2: Foundational - Interface Definitions (US1 + US2 Combined)
+
+**Purpose**: Update interface definitions that MUST be complete before handler refactoring
+
+**⚠️ CRITICAL**: Handler refactoring (US3) cannot begin until this phase is complete
+
+**Goal**: Change `UpdatableBatchTable.Update` and `DeletableBatchTable.Delete` signatures from `array.RecordReader` to `arrow.RecordBatch`
+
+### Implementation
+
+- [x] T001 [US1] [US2] Update UpdatableBatchTable.Update signature in catalog/table.go - change parameter from `rows array.RecordReader` to `rows arrow.RecordBatch`
+- [x] T002 [US1] [US2] Update DeletableBatchTable.Delete signature in catalog/table.go - change parameter from `rows array.RecordReader` to `rows arrow.RecordBatch`
+- [x] T003 [US1] [US2] Update godoc comments for both interfaces in catalog/table.go - document null rowid error requirement and memory management
+- [x] T004 [P] [US1] [US2] Add ErrNullRowID sentinel error in catalog/types.go
+
+**Checkpoint**: Interface definitions updated - handler refactoring can now begin
+
+---
+
+## Phase 3: User Story 3 - Simplified Handler Implementation (Priority: P2)
+
+**Goal**: Refactor handleDoExchangeUpdate and handleDoExchangeDelete to pass Record directly instead of wrapping in RecordReader
+
+**Independent Test**: Integration tests pass after refactoring (tested in Phase 4)
+
+### Implementation
+
+- [x] T005 [US3] Refactor newUpdateProcessor in flight/doexchange_dml.go - remove RecordReader wrapper, pass batch directly to Update method
+- [x] T006 [US3] Refactor newDeleteProcessor in flight/doexchange_dml.go - remove RecordReader wrapper, pass batch directly to Delete method
+- [x] T007 [US3] Verify backward compatibility - ensure legacy interface (UpdatableTable, DeletableTable) path still works in flight/doexchange_dml.go
+
+**Checkpoint**: Handler refactoring complete - ready for test updates
+
+---
+
+## Phase 4: Integration Tests
+
+**Goal**: Update test table implementations to use new signatures
+
+**Purpose**: Verify the signature change works end-to-end with DuckDB
+
+### Implementation
+
+- [x] T008 [US1] [US2] Update batchDMLTable.Update method in tests/integration/dml_batch_test.go - change signature from RecordReader to RecordBatch, remove Next() loop
+- [x] T009 [US1] [US2] Update batchDMLTable.Delete method in tests/integration/dml_batch_test.go - change signature from RecordReader to RecordBatch, remove Next() loop
+- [x] T010 [US1] [US2] Add null rowid handling to test table Update method in tests/integration/dml_batch_test.go - return error if rowid column has nulls
+- [x] T011 [US1] [US2] Add null rowid handling to test table Delete method in tests/integration/dml_batch_test.go - return error if rowid column has nulls
+- [x] T012 Run integration tests with race detector: `cd tests && go test -race ./integration/... -run TestDMLBatch`
+
+**Checkpoint**: All integration tests pass - ready for examples and documentation
+
+---
+
+## Phase 5: User Story 4 - Updated Examples and Documentation (Priority: P3)
+
+**Goal**: Update documentation and examples to reflect new method signatures
+
+**Independent Test**: Documentation review and example compilation
+
+### Implementation
+
+- [x] T013 [P] [US4] Update api-guide.md batch interface documentation in docs/api-guide.md - update method signatures and add migration notes
+- [x] T014 [P] [US4] Update examples/dml/main.go comments - clarify that legacy interface (UpdatableTable) is still supported and batch interface uses RecordBatch
+- [x] T015 [US4] Review and verify examples compile: `cd examples && go build ./...`
+
+**Checkpoint**: Documentation and examples updated
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and cleanup
+
+- [x] T016 Run full test suite with race detector: `go test -race ./...`
+- [x] T017 Run linter: `golangci-lint run ./...`
+- [x] T018 Verify backward compatibility by running dml_test.go (legacy interface tests): `cd tests && go test -race ./integration/... -run TestDML`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: N/A - no setup needed
+- **Phase 2 (Foundational)**: No dependencies - start immediately
+- **Phase 3 (US3 Handlers)**: Depends on Phase 2 completion
+- **Phase 4 (Tests)**: Depends on Phase 3 completion
+- **Phase 5 (US4 Docs)**: Can start after Phase 2, but recommend after Phase 4 to document final API
+- **Phase 6 (Polish)**: Depends on all previous phases
+
+### User Story Dependencies
+
+```
+US1 + US2 (Interface Definitions) ──┬──► US3 (Handler Refactoring) ──► Tests ──► US4 (Docs)
+                                    │
+                                    └──► US4 (Docs can start early for interface changes)
+```
+
+- **US1 + US2**: Combined because they modify the same file (catalog/table.go) and are both P1 priority
+- **US3**: Depends on US1+US2 - handlers call the interface methods
+- **US4**: Can partially start after US1+US2, but should be finalized after tests pass
+
+### Within Each Phase
+
+- Tasks without [P] marker must complete in order
+- Tasks with [P] marker within same phase can run in parallel
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel (different files)
+- T013 and T014 can run in parallel (different files)
+- T008/T009 are in same file, must be sequential
+- T010/T011 are in same file, must be sequential
+
+---
+
+## Parallel Example: Phase 2
+
+```bash
+# Sequential (same file):
+Task T001: Update UpdatableBatchTable.Update signature
+Task T002: Update DeletableBatchTable.Delete signature
+Task T003: Update godoc comments
+
+# Parallel with above (different file):
+Task T004: Add ErrNullRowID sentinel error
+```
+
+## Parallel Example: Phase 5
+
+```bash
+# Can run in parallel (different files):
+Task T013: Update api-guide.md
+Task T014: Update examples/dml/main.go comments
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2 + US3)
+
+1. Complete Phase 2: Interface Definitions (US1 + US2)
+2. Complete Phase 3: Handler Refactoring (US3)
+3. Complete Phase 4: Integration Tests
+4. **STOP and VALIDATE**: All integration tests pass
+5. Proceed to documentation
+
+### Incremental Delivery
+
+1. Phase 2 → Interface definitions updated
+2. Phase 3 → Handlers simplified
+3. Phase 4 → Tests verify everything works
+4. Phase 5 → Documentation updated
+5. Phase 6 → Final validation
+
+### Single Developer Strategy
+
+Execute phases sequentially in order. Total estimated tasks: 18
+
+---
+
+## Notes
+
+- All tasks modify existing files (refactoring, not new feature)
+- Legacy interfaces (UpdatableTable, DeletableTable) remain unchanged
+- Memory management pattern unchanged (caller releases Record after method returns)
+- Null rowid handling is a new requirement from clarification session
+- Test tasks run existing tests - no new test files created

--- a/tests/integration/dynamic_catalog_test.go
+++ b/tests/integration/dynamic_catalog_test.go
@@ -544,6 +544,19 @@ func (t *mockDynamicTable) RenameField(_ context.Context, columnPath []string, _
 	return nil
 }
 
+// RemoveField removes a field from a struct-typed column (mock: simplified implementation).
+func (t *mockDynamicTable) RemoveField(_ context.Context, columnPath []string, opts catalog.RemoveFieldOptions) error {
+	// Mock implementation: just return success if path is valid
+	// Real implementation would find the struct column and remove the field
+	if len(columnPath) == 0 {
+		if opts.IgnoreNotFound {
+			return nil
+		}
+		return catalog.ErrNotFound
+	}
+	return nil
+}
+
 // HasColumn checks if a column exists (for testing).
 func (t *mockDynamicTable) HasColumn(name string) bool {
 	t.mu.RLock()


### PR DESCRIPTION
## Summary

- Simplify `UpdatableBatchTable.Update` and `DeletableBatchTable.Delete` signatures by changing parameter type from `array.RecordReader` to `arrow.RecordBatch`
- Add `ErrNullRowID` sentinel error for null rowid validation in batch operations
- Add `RemoveField` method to `DynamicTable` interface for removing fields from struct-typed columns
- Add `remove_field` action handler implementation

## Changes

### Interface Changes
- `UpdatableBatchTable.Update(ctx, rows array.RecordReader, opts)` → `Update(ctx, rows arrow.RecordBatch, opts)`
- `DeletableBatchTable.Delete(ctx, rows array.RecordReader, opts)` → `Delete(ctx, rows arrow.RecordBatch, opts)`
- New: `DynamicTable.RemoveField(ctx, columnPath []string, opts RemoveFieldOptions) error`

### Implementation
- Refactored `newUpdateProcessor` and `newDeleteProcessor` handlers to pass `RecordBatch` directly
- Added `handleRemoveFieldAction` for the `remove_field` DoAction
- Backward compatibility maintained for legacy interfaces (`UpdatableTable`, `DeletableTable`)

### Documentation
- Updated `docs/api-guide.md` with new signatures and `RemoveField` method
- Updated example comments in `examples/dml/main.go`

## Test plan

- [x] All unit tests pass with race detector
- [x] All integration tests pass (including DDL tests)
- [x] Linter passes with 0 issues
- [x] Examples compile successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)