### PR TITLE
Enhanced the list of supported table function parameters types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,9 @@ go work sync
 
 ## Code Style
 
-- Follow idiomatic Go style (gofmt, golangci-lint)
+- Follow [Uber Go Style Guide](https://github.com/uber-go/guide/blob/master/style.md)
+- Use `any` instead of `interface{}` for empty interface types
+- Avoid `else` blocks - prefer early returns with `if` checks; `else` is acceptable for simple cases (3-5 lines inside condition blocks)
 - All public APIs must have godoc comments
 - No silent failures - errors must be handled explicitly
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -389,13 +389,13 @@ func (m *mockTableFunc) Signature() catalog.FunctionSignature {
 	}
 }
 
-func (m *mockTableFunc) SchemaForParameters(ctx context.Context, params []interface{}) (*arrow.Schema, error) {
+func (m *mockTableFunc) SchemaForParameters(ctx context.Context, params []any) (*arrow.Schema, error) {
 	return arrow.NewSchema([]arrow.Field{
 		{Name: "result", Type: arrow.BinaryTypes.String},
 	}, nil), nil
 }
 
-func (m *mockTableFunc) Execute(ctx context.Context, params []interface{}, opts *catalog.ScanOptions) (array.RecordReader, error) {
+func (m *mockTableFunc) Execute(ctx context.Context, params []any, opts *catalog.ScanOptions) (array.RecordReader, error) {
 	schema, _ := m.SchemaForParameters(ctx, params)
 	return testScanFunc(schema)(ctx, opts)
 }

--- a/catalog/static_test.go
+++ b/catalog/static_test.go
@@ -396,13 +396,13 @@ func (m *mockTableFunc) Signature() FunctionSignature {
 	}
 }
 
-func (m *mockTableFunc) SchemaForParameters(ctx context.Context, params []interface{}) (*arrow.Schema, error) {
+func (m *mockTableFunc) SchemaForParameters(ctx context.Context, params []any) (*arrow.Schema, error) {
 	return arrow.NewSchema([]arrow.Field{
 		{Name: "result", Type: arrow.BinaryTypes.String},
 	}, nil), nil
 }
 
-func (m *mockTableFunc) Execute(ctx context.Context, params []interface{}, opts *ScanOptions) (array.RecordReader, error) {
+func (m *mockTableFunc) Execute(ctx context.Context, params []any, opts *ScanOptions) (array.RecordReader, error) {
 	schema, _ := m.SchemaForParameters(ctx, params)
 	return testScanFunc(schema)(ctx, opts)
 }

--- a/examples/dynamic/README.md
+++ b/examples/dynamic/README.md
@@ -140,9 +140,9 @@ func (s *DynamicSchema) canAccess(identity string) bool {
 metricsTable := &LiveTable{
     name:   "metrics",
     schema: metricsSchema,
-    getData: func() [][]interface{} {
+    getData: func() [][]any {
         // Return current metrics on each query
-        return [][]interface{}{
+        return [][]any{
             {time.Now().Unix(), "uptime_seconds", int64(elapsed)},
         }
     },

--- a/examples/dynamic/main.go
+++ b/examples/dynamic/main.go
@@ -171,7 +171,7 @@ type LiveTable struct {
 	name    string
 	comment string
 	schema  *arrow.Schema
-	getData func() [][]interface{} // Function that returns current data
+	getData func() [][]any // Function that returns current data
 }
 
 func (t *LiveTable) Name() string {
@@ -231,10 +231,10 @@ func main() {
 		name:    "metrics",
 		comment: "Live server metrics",
 		schema:  metricsSchema,
-		getData: func() [][]interface{} {
+		getData: func() [][]any {
 			// Return current metrics
 			elapsed := time.Since(startTime).Seconds()
-			return [][]interface{}{
+			return [][]any{
 				{time.Now().Unix(), "uptime_seconds", int64(elapsed)},
 				{time.Now().Unix(), "request_count", int64(100)},
 			}
@@ -257,8 +257,8 @@ func main() {
 		name:    "settings",
 		comment: "Server configuration",
 		schema:  adminTableSchema,
-		getData: func() [][]interface{} {
-			return [][]interface{}{
+		getData: func() [][]any {
+			return [][]any{
 				{"max_connections", "1000"},
 				{"log_level", "info"},
 			}

--- a/examples/tls/main.go
+++ b/examples/tls/main.go
@@ -103,7 +103,7 @@ func createSampleCatalog() (catalog.Catalog, error) {
 		{Name: "message", Type: arrow.BinaryTypes.String},
 	}, nil)
 
-	data := [][]interface{}{
+	data := [][]any{
 		{int64(1), "Secure connection established"},
 		{int64(2), "TLS encryption active"},
 	}
@@ -124,7 +124,7 @@ func createSampleCatalog() (catalog.Catalog, error) {
 }
 
 // buildRecord creates an Arrow record from test data.
-func buildRecord(schema *arrow.Schema, data [][]interface{}) arrow.RecordBatch {
+func buildRecord(schema *arrow.Schema, data [][]any) arrow.RecordBatch {
 	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
 	defer builder.Release()
 

--- a/flight/doaction.go
+++ b/flight/doaction.go
@@ -312,7 +312,7 @@ func (s *Server) serializeSchemaContents(ctx context.Context, schema catalog.Sch
 		}
 
 		// Generate ticket for this table
-		ticket, err := EncodeTicket(s.CatalogName(), schema.Name(), table.Name())
+		ticket, err := EncodeTableTicket(s.CatalogName(), schema.Name(), table.Name())
 		if err != nil {
 			return "", "", fmt.Errorf("failed to encode ticket: %w", err)
 		}

--- a/flight/doaction.go
+++ b/flight/doaction.go
@@ -288,7 +288,7 @@ func (s *Server) serializeSchemaContents(ctx context.Context, schema catalog.Sch
 		}
 
 		// Create Flight app_metadata matching AirportSerializedFlightAppMetadata
-		appMetadata := map[string]interface{}{
+		appMetadata := map[string]any{
 			"type":         "table",
 			"schema":       schema.Name(),
 			"catalog":      s.CatalogName(),
@@ -368,7 +368,7 @@ func (s *Server) serializeSchemaContents(ctx context.Context, schema catalog.Sch
 		outputSchema := arrow.NewSchema([]arrow.Field{}, nil)
 
 		// Create Flight app_metadata for table function
-		appMetadata := map[string]interface{}{
+		appMetadata := map[string]any{
 			"type":         "table_function",
 			"schema":       schema.Name(),
 			"catalog":      s.CatalogName(),
@@ -448,7 +448,7 @@ func (s *Server) serializeSchemaContents(ctx context.Context, schema catalog.Sch
 		}, nil)
 
 		// Create Flight app_metadata for scalar function
-		appMetadata := map[string]interface{}{
+		appMetadata := map[string]any{
 			"type":         "scalar_function",
 			"schema":       schema.Name(),
 			"catalog":      s.CatalogName(),
@@ -538,7 +538,7 @@ func (s *Server) serializeSchemaContents(ctx context.Context, schema catalog.Sch
 		outputSchema := arrow.NewSchema([]arrow.Field{}, nil)
 
 		// Create Flight app_metadata for table function (in/out)
-		appMetadata := map[string]interface{}{
+		appMetadata := map[string]any{
 			"type":         "table_function",
 			"schema":       schema.Name(),
 			"catalog":      s.CatalogName(),
@@ -612,7 +612,7 @@ func (s *Server) serializeSchemaContents(ctx context.Context, schema catalog.Sch
 	}
 
 	// Wrap in AirportSerializedCompressedContent format: [length, data]
-	compressedContent := []interface{}{
+	compressedContent := []any{
 		uint32(len(uncompressed)),
 		string(compressed),
 	}

--- a/flight/doaction_ddl.go
+++ b/flight/doaction_ddl.go
@@ -1729,7 +1729,7 @@ func (s *Server) buildTableFlightInfo(_ context.Context, schema catalog.Schema, 
 	}
 
 	// Generate ticket for this table
-	ticket, err := EncodeTicket(s.CatalogName(), schema.Name(), table.Name())
+	ticket, err := EncodeTableTicket(s.CatalogName(), schema.Name(), table.Name())
 	if err != nil {
 		return nil, err
 	}

--- a/flight/doaction_ddl.go
+++ b/flight/doaction_ddl.go
@@ -229,7 +229,7 @@ func (s *Server) handleCreateSchemaAction(ctx context.Context, action *flight.Ac
 	}
 
 	// Build AirportSerializedContentsWithSHA256Hash response
-	response := map[string]interface{}{
+	response := map[string]any{
 		"sha256":     sha256Hash,
 		"url":        nil,
 		"serialized": []byte(serializedContents),
@@ -1705,7 +1705,7 @@ func (s *Server) buildTableFlightInfo(_ context.Context, schema catalog.Schema, 
 	}
 
 	// Create Flight app_metadata matching AirportSerializedFlightAppMetadata
-	appMetadata := map[string]interface{}{
+	appMetadata := map[string]any{
 		"type":         "table",
 		"schema":       schema.Name(),
 		"catalog":      s.CatalogName(),

--- a/flight/doaction_metadata.go
+++ b/flight/doaction_metadata.go
@@ -133,7 +133,7 @@ func (s *Server) handleFlightInfo(ctx context.Context, action *flight.Action, st
 
 	// Prepare app_metadata - same structure as regular tables
 	// Time travel info is encoded in the ticket, not in app_metadata
-	appMetadata, _ := msgpack.Encode(map[string]interface{}{
+	appMetadata, _ := msgpack.Encode(map[string]any{
 		"type":         "table",
 		"schema":       schema.Name(),
 		"catalog":      s.CatalogName(),
@@ -548,7 +548,7 @@ func (s *Server) handleCreateTransaction(ctx context.Context, action *flight.Act
 
 	// If no TransactionManager is configured, return nil identifier
 	if s.txManager == nil {
-		response := map[string]interface{}{
+		response := map[string]any{
 			"identifier": nil,
 		}
 
@@ -574,7 +574,7 @@ func (s *Server) handleCreateTransaction(ctx context.Context, action *flight.Act
 		return status.Errorf(codes.Internal, "failed to create transaction: %v", err)
 	}
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"identifier": txID,
 	}
 
@@ -612,7 +612,7 @@ func (s *Server) handleGetTransactionStatus(ctx context.Context, action *flight.
 
 	// If no TransactionManager is configured, return not found
 	if s.txManager == nil {
-		response := map[string]interface{}{
+		response := map[string]any{
 			"status": "",
 			"exists": false,
 		}
@@ -634,7 +634,7 @@ func (s *Server) handleGetTransactionStatus(ctx context.Context, action *flight.
 	// Get transaction status
 	state, exists := s.txManager.GetTransactionStatus(ctx, params.TransactionID)
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"status": string(state),
 		"exists": exists,
 	}
@@ -655,8 +655,8 @@ func (s *Server) handleGetTransactionStatus(ctx context.Context, action *flight.
 }
 
 // extractScalarValue extracts a scalar value from an Arrow array at the given index.
-// This is used to convert Arrow array values to Go interface{} values for function parameters.
-func extractScalarValue(arr arrow.Array, idx int) interface{} {
+// This is used to convert Arrow array values to Go any values for function parameters.
+func extractScalarValue(arr arrow.Array, idx int) any {
 	if arr.IsNull(idx) {
 		return nil
 	}
@@ -688,6 +688,55 @@ func extractScalarValue(arr arrow.Array, idx int) interface{} {
 		return a.Value(idx)
 	case *array.Boolean:
 		return a.Value(idx)
+	case *array.Date32:
+		// Return as time.Time (days since Unix epoch)
+		return a.Value(idx).ToTime()
+	case *array.Date64:
+		// Return as time.Time (milliseconds since Unix epoch)
+		return a.Value(idx).ToTime()
+	case *array.Timestamp:
+		// Return as time.Time
+		return a.Value(idx).ToTime(a.DataType().(*arrow.TimestampType).Unit)
+	case *array.Time32:
+		// Return as int32 (seconds or milliseconds since midnight depending on unit)
+		return int32(a.Value(idx))
+	case *array.Time64:
+		// Return as int64 (microseconds or nanoseconds since midnight depending on unit)
+		return int64(a.Value(idx))
+	case *array.Decimal128:
+		// Return as string representation for precision
+		return a.Value(idx).ToString(a.DataType().(*arrow.Decimal128Type).Scale)
+	case *array.List:
+		// Return as slice of values
+		start, end := a.ValueOffsets(idx)
+		values := a.ListValues()
+		result := make([]any, end-start)
+		for i := start; i < end; i++ {
+			result[i-start] = extractScalarValue(values, int(i))
+		}
+		return result
+	case *array.Struct:
+		// Return as map of field name -> value
+		structType := a.DataType().(*arrow.StructType)
+		result := make(map[string]any, a.NumField())
+		for i := 0; i < a.NumField(); i++ {
+			fieldName := structType.Field(i).Name
+			result[fieldName] = extractScalarValue(a.Field(i), idx)
+		}
+		return result
+	case *array.Map:
+		// Return as map[any]any
+		// Map is stored as List of Structs with "key" and "value" fields
+		start, end := a.ValueOffsets(idx)
+		keys := a.Keys()
+		items := a.Items()
+		result := make(map[any]any, end-start)
+		for i := start; i < end; i++ {
+			key := extractScalarValue(keys, int(i))
+			value := extractScalarValue(items, int(i))
+			result[key] = value
+		}
+		return result
 	default:
 		// For unsupported types, return nil
 		return nil

--- a/flight/doaction_metadata.go
+++ b/flight/doaction_metadata.go
@@ -288,21 +288,19 @@ func (s *Server) parseDescriptor(data string) (*flight.FlightDescriptor, error) 
 // createTableFunctionTicket creates a ticket for table function execution.
 func (s *Server) createTableFunctionTicket(ctx context.Context, schemaName, functionName string, request *endpointsRequest) ([]byte, error) {
 	paramBytes := []byte(request.Parameters.TableFunctionParameters)
-	s.logger.Debug("Parsing table function parameters",
-		"param_size", len(paramBytes),
-		"first_bytes", fmt.Sprintf("%x", paramBytes[:min(20, len(paramBytes))]),
-	)
-
-	params, err := s.extractFunctionParams(paramBytes)
-	if err != nil {
-		return nil, err
-	}
-
 	ticketData := TicketData{
 		Catalog:        s.CatalogName(),
 		Schema:         schemaName,
 		TableFunction:  functionName,
-		FunctionParams: params,
+		FunctionParams: paramBytes,
+	}
+	s.logger.Debug("Parsing table function parameters",
+		"param_size", len(paramBytes),
+		"first_bytes", fmt.Sprintf("%x", paramBytes[:min(20, len(paramBytes))]),
+	)
+	params, err := s.extractFunctionParams(paramBytes)
+	if err != nil {
+		return nil, err
 	}
 
 	ticketData.Columns = s.resolveTableFunctionColumns(ctx, schemaName, functionName, params, request.Parameters.ColumnIDs)

--- a/flight/doaction_metadata.go
+++ b/flight/doaction_metadata.go
@@ -661,23 +661,23 @@ func extractScalarValue(arr arrow.Array, idx int) any {
 
 	switch a := arr.(type) {
 	case *array.Int8:
-		return int64(a.Value(idx))
+		return a.Value(idx)
 	case *array.Int16:
-		return int64(a.Value(idx))
+		return a.Value(idx)
 	case *array.Int32:
-		return int64(a.Value(idx))
+		return a.Value(idx)
 	case *array.Int64:
 		return a.Value(idx)
 	case *array.Uint8:
-		return int64(a.Value(idx))
+		return a.Value(idx)
 	case *array.Uint16:
-		return int64(a.Value(idx))
+		return a.Value(idx)
 	case *array.Uint32:
-		return int64(a.Value(idx))
+		return a.Value(idx)
 	case *array.Uint64:
-		return int64(a.Value(idx))
+		return a.Value(idx)
 	case *array.Float32:
-		return float64(a.Value(idx))
+		return a.Value(idx)
 	case *array.Float64:
 		return a.Value(idx)
 	case *array.String:
@@ -736,7 +736,7 @@ func extractScalarValue(arr arrow.Array, idx int) any {
 		}
 		return result
 	default:
-		// For unsupported types, return nil
+		// For unsupported types, return the array itself
 		return nil
 	}
 }

--- a/flight/doaction_metadata_test.go
+++ b/flight/doaction_metadata_test.go
@@ -26,7 +26,7 @@ func TestExtractScalarValue_Integers(t *testing.T) {
 				b.Append(42)
 				return b.NewArray()
 			},
-			expected: int64(42),
+			expected: int8(42),
 		},
 		{
 			name: "Int16",
@@ -36,7 +36,7 @@ func TestExtractScalarValue_Integers(t *testing.T) {
 				b.Append(1000)
 				return b.NewArray()
 			},
-			expected: int64(1000),
+			expected: int16(1000),
 		},
 		{
 			name: "Int32",
@@ -46,7 +46,7 @@ func TestExtractScalarValue_Integers(t *testing.T) {
 				b.Append(100000)
 				return b.NewArray()
 			},
-			expected: int64(100000),
+			expected: int32(100000),
 		},
 		{
 			name: "Int64",
@@ -66,7 +66,7 @@ func TestExtractScalarValue_Integers(t *testing.T) {
 				b.Append(255)
 				return b.NewArray()
 			},
-			expected: int64(255),
+			expected: uint8(255),
 		},
 		{
 			name: "Uint16",
@@ -76,7 +76,7 @@ func TestExtractScalarValue_Integers(t *testing.T) {
 				b.Append(65535)
 				return b.NewArray()
 			},
-			expected: int64(65535),
+			expected: uint16(65535),
 		},
 		{
 			name: "Uint32",
@@ -86,7 +86,7 @@ func TestExtractScalarValue_Integers(t *testing.T) {
 				b.Append(4294967295)
 				return b.NewArray()
 			},
-			expected: int64(4294967295),
+			expected: uint32(4294967295),
 		},
 		{
 			name: "Uint64",
@@ -96,7 +96,7 @@ func TestExtractScalarValue_Integers(t *testing.T) {
 				b.Append(1844674407370955161)
 				return b.NewArray()
 			},
-			expected: int64(1844674407370955161),
+			expected: uint64(1844674407370955161),
 		},
 	}
 
@@ -124,8 +124,8 @@ func TestExtractScalarValue_Floats(t *testing.T) {
 		defer arr.Release()
 
 		result := extractScalarValue(arr, 0)
-		if v, ok := result.(float64); !ok || v < 3.13 || v > 3.15 {
-			t.Errorf("expected ~3.14, got %v", result)
+		if v, ok := result.(float32); !ok || v < 3.13 || v > 3.15 {
+			t.Errorf("expected ~3.14 (float32), got %v (%T)", result, result)
 		}
 	})
 

--- a/flight/doaction_metadata_test.go
+++ b/flight/doaction_metadata_test.go
@@ -1,0 +1,499 @@
+package flight
+
+import (
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+func TestExtractScalarValue_Integers(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	tests := []struct {
+		name     string
+		buildArr func() arrow.Array
+		expected any
+	}{
+		{
+			name: "Int8",
+			buildArr: func() arrow.Array {
+				b := array.NewInt8Builder(alloc)
+				defer b.Release()
+				b.Append(42)
+				return b.NewArray()
+			},
+			expected: int64(42),
+		},
+		{
+			name: "Int16",
+			buildArr: func() arrow.Array {
+				b := array.NewInt16Builder(alloc)
+				defer b.Release()
+				b.Append(1000)
+				return b.NewArray()
+			},
+			expected: int64(1000),
+		},
+		{
+			name: "Int32",
+			buildArr: func() arrow.Array {
+				b := array.NewInt32Builder(alloc)
+				defer b.Release()
+				b.Append(100000)
+				return b.NewArray()
+			},
+			expected: int64(100000),
+		},
+		{
+			name: "Int64",
+			buildArr: func() arrow.Array {
+				b := array.NewInt64Builder(alloc)
+				defer b.Release()
+				b.Append(9223372036854775807)
+				return b.NewArray()
+			},
+			expected: int64(9223372036854775807),
+		},
+		{
+			name: "Uint8",
+			buildArr: func() arrow.Array {
+				b := array.NewUint8Builder(alloc)
+				defer b.Release()
+				b.Append(255)
+				return b.NewArray()
+			},
+			expected: int64(255),
+		},
+		{
+			name: "Uint16",
+			buildArr: func() arrow.Array {
+				b := array.NewUint16Builder(alloc)
+				defer b.Release()
+				b.Append(65535)
+				return b.NewArray()
+			},
+			expected: int64(65535),
+		},
+		{
+			name: "Uint32",
+			buildArr: func() arrow.Array {
+				b := array.NewUint32Builder(alloc)
+				defer b.Release()
+				b.Append(4294967295)
+				return b.NewArray()
+			},
+			expected: int64(4294967295),
+		},
+		{
+			name: "Uint64",
+			buildArr: func() arrow.Array {
+				b := array.NewUint64Builder(alloc)
+				defer b.Release()
+				b.Append(1844674407370955161)
+				return b.NewArray()
+			},
+			expected: int64(1844674407370955161),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			arr := tt.buildArr()
+			defer arr.Release()
+
+			result := extractScalarValue(arr, 0)
+			if result != tt.expected {
+				t.Errorf("expected %v (%T), got %v (%T)", tt.expected, tt.expected, result, result)
+			}
+		})
+	}
+}
+
+func TestExtractScalarValue_Floats(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	t.Run("Float32", func(t *testing.T) {
+		b := array.NewFloat32Builder(alloc)
+		defer b.Release()
+		b.Append(3.14)
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if v, ok := result.(float64); !ok || v < 3.13 || v > 3.15 {
+			t.Errorf("expected ~3.14, got %v", result)
+		}
+	})
+
+	t.Run("Float64", func(t *testing.T) {
+		b := array.NewFloat64Builder(alloc)
+		defer b.Release()
+		b.Append(3.141592653589793)
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if result != 3.141592653589793 {
+			t.Errorf("expected 3.141592653589793, got %v", result)
+		}
+	})
+}
+
+func TestExtractScalarValue_StringAndBinary(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	t.Run("String", func(t *testing.T) {
+		b := array.NewStringBuilder(alloc)
+		defer b.Release()
+		b.Append("hello world")
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if result != "hello world" {
+			t.Errorf("expected 'hello world', got %v", result)
+		}
+	})
+
+	t.Run("Binary", func(t *testing.T) {
+		b := array.NewBinaryBuilder(alloc, arrow.BinaryTypes.Binary)
+		defer b.Release()
+		b.Append([]byte{0x01, 0x02, 0x03})
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if v, ok := result.([]byte); !ok || len(v) != 3 || v[0] != 0x01 {
+			t.Errorf("expected []byte{0x01, 0x02, 0x03}, got %v", result)
+		}
+	})
+}
+
+func TestExtractScalarValue_Boolean(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	t.Run("True", func(t *testing.T) {
+		b := array.NewBooleanBuilder(alloc)
+		defer b.Release()
+		b.Append(true)
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if result != true {
+			t.Errorf("expected true, got %v", result)
+		}
+	})
+
+	t.Run("False", func(t *testing.T) {
+		b := array.NewBooleanBuilder(alloc)
+		defer b.Release()
+		b.Append(false)
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if result != false {
+			t.Errorf("expected false, got %v", result)
+		}
+	})
+}
+
+func TestExtractScalarValue_Null(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	b := array.NewInt64Builder(alloc)
+	defer b.Release()
+	b.AppendNull()
+	arr := b.NewArray()
+	defer arr.Release()
+
+	result := extractScalarValue(arr, 0)
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+
+func TestExtractScalarValue_Date(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	t.Run("Date32", func(t *testing.T) {
+		b := array.NewDate32Builder(alloc)
+		defer b.Release()
+		// 19716 days since epoch = 2023-12-25
+		b.Append(arrow.Date32(19716))
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if v, ok := result.(time.Time); !ok {
+			t.Errorf("expected time.Time, got %T", result)
+		} else if v.Year() != 2023 || v.Month() != 12 || v.Day() != 25 {
+			t.Errorf("expected 2023-12-25, got %v", v)
+		}
+	})
+
+	t.Run("Date64", func(t *testing.T) {
+		b := array.NewDate64Builder(alloc)
+		defer b.Release()
+		// 1703462400000 ms = 2023-12-25 00:00:00 UTC
+		b.Append(arrow.Date64(1703462400000))
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if v, ok := result.(time.Time); !ok {
+			t.Errorf("expected time.Time, got %T", result)
+		} else if v.Year() != 2023 || v.Month() != 12 || v.Day() != 25 {
+			t.Errorf("expected 2023-12-25, got %v", v)
+		}
+	})
+}
+
+func TestExtractScalarValue_Timestamp(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	t.Run("TimestampSecond", func(t *testing.T) {
+		dt := &arrow.TimestampType{Unit: arrow.Second}
+		b := array.NewTimestampBuilder(alloc, dt)
+		defer b.Release()
+		// 1703462400 seconds = 2023-12-25 00:00:00 UTC
+		b.Append(arrow.Timestamp(1703462400))
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if v, ok := result.(time.Time); !ok {
+			t.Errorf("expected time.Time, got %T", result)
+		} else if v.Year() != 2023 || v.Month() != 12 || v.Day() != 25 {
+			t.Errorf("expected 2023-12-25, got %v", v)
+		}
+	})
+
+	t.Run("TimestampMillisecond", func(t *testing.T) {
+		dt := &arrow.TimestampType{Unit: arrow.Millisecond}
+		b := array.NewTimestampBuilder(alloc, dt)
+		defer b.Release()
+		b.Append(arrow.Timestamp(1703462400000))
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if v, ok := result.(time.Time); !ok {
+			t.Errorf("expected time.Time, got %T", result)
+		} else if v.Year() != 2023 || v.Month() != 12 || v.Day() != 25 {
+			t.Errorf("expected 2023-12-25, got %v", v)
+		}
+	})
+}
+
+func TestExtractScalarValue_Time(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	t.Run("Time32Second", func(t *testing.T) {
+		dt := &arrow.Time32Type{Unit: arrow.Second}
+		b := array.NewTime32Builder(alloc, dt)
+		defer b.Release()
+		// 3661 seconds = 01:01:01
+		b.Append(arrow.Time32(3661))
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if v, ok := result.(int32); !ok || v != 3661 {
+			t.Errorf("expected int32(3661), got %v (%T)", result, result)
+		}
+	})
+
+	t.Run("Time64Microsecond", func(t *testing.T) {
+		dt := &arrow.Time64Type{Unit: arrow.Microsecond}
+		b := array.NewTime64Builder(alloc, dt)
+		defer b.Release()
+		// 3661000000 microseconds = 01:01:01
+		b.Append(arrow.Time64(3661000000))
+		arr := b.NewArray()
+		defer arr.Release()
+
+		result := extractScalarValue(arr, 0)
+		if v, ok := result.(int64); !ok || v != 3661000000 {
+			t.Errorf("expected int64(3661000000), got %v (%T)", result, result)
+		}
+	})
+}
+
+func TestExtractScalarValue_Decimal128(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	dt := &arrow.Decimal128Type{Precision: 10, Scale: 2}
+	b := array.NewDecimal128Builder(alloc, dt)
+	defer b.Release()
+	// 12345 with scale 2 = 123.45
+	b.Append(decimal128.FromI64(12345))
+	arr := b.NewArray()
+	defer arr.Release()
+
+	result := extractScalarValue(arr, 0)
+	if v, ok := result.(string); !ok || v != "123.45" {
+		t.Errorf("expected '123.45', got %v (%T)", result, result)
+	}
+}
+
+func TestExtractScalarValue_List(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	lb := array.NewListBuilder(alloc, arrow.PrimitiveTypes.Int64)
+	defer lb.Release()
+
+	vb := lb.ValueBuilder().(*array.Int64Builder)
+	lb.Append(true)
+	vb.Append(1)
+	vb.Append(2)
+	vb.Append(3)
+
+	arr := lb.NewArray()
+	defer arr.Release()
+
+	result := extractScalarValue(arr, 0)
+	if v, ok := result.([]any); !ok {
+		t.Errorf("expected []any, got %T", result)
+	} else if len(v) != 3 {
+		t.Errorf("expected 3 elements, got %d", len(v))
+	} else if v[0] != int64(1) || v[1] != int64(2) || v[2] != int64(3) {
+		t.Errorf("expected [1, 2, 3], got %v", v)
+	}
+}
+
+func TestExtractScalarValue_Struct(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	fields := []arrow.Field{
+		{Name: "name", Type: arrow.BinaryTypes.String},
+		{Name: "age", Type: arrow.PrimitiveTypes.Int64},
+	}
+	structType := arrow.StructOf(fields...)
+
+	sb := array.NewStructBuilder(alloc, structType)
+	defer sb.Release()
+
+	nameBuilder := sb.FieldBuilder(0).(*array.StringBuilder)
+	ageBuilder := sb.FieldBuilder(1).(*array.Int64Builder)
+
+	sb.Append(true)
+	nameBuilder.Append("Alice")
+	ageBuilder.Append(30)
+
+	arr := sb.NewArray()
+	defer arr.Release()
+
+	result := extractScalarValue(arr, 0)
+	v, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", result)
+	}
+	if v["name"] != "Alice" {
+		t.Errorf("expected name='Alice', got %v", v["name"])
+	}
+	if v["age"] != int64(30) {
+		t.Errorf("expected age=30, got %v", v["age"])
+	}
+}
+
+func TestExtractScalarValue_Map(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	mb := array.NewMapBuilder(alloc, arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int64, false)
+	defer mb.Release()
+
+	kb := mb.KeyBuilder().(*array.StringBuilder)
+	ib := mb.ItemBuilder().(*array.Int64Builder)
+
+	mb.Append(true)
+	kb.Append("a")
+	ib.Append(1)
+	kb.Append("b")
+	ib.Append(2)
+
+	arr := mb.NewArray()
+	defer arr.Release()
+
+	result := extractScalarValue(arr, 0)
+	v, ok := result.(map[any]any)
+	if !ok {
+		t.Fatalf("expected map[any]any, got %T", result)
+	}
+	if len(v) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(v))
+	}
+	if v["a"] != int64(1) {
+		t.Errorf("expected a=1, got %v", v["a"])
+	}
+	if v["b"] != int64(2) {
+		t.Errorf("expected b=2, got %v", v["b"])
+	}
+}
+
+func TestExtractScalarValue_MultipleIndices(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	b := array.NewStringBuilder(alloc)
+	defer b.Release()
+	b.Append("first")
+	b.Append("second")
+	b.Append("third")
+	arr := b.NewArray()
+	defer arr.Release()
+
+	if extractScalarValue(arr, 0) != "first" {
+		t.Error("index 0 should be 'first'")
+	}
+	if extractScalarValue(arr, 1) != "second" {
+		t.Error("index 1 should be 'second'")
+	}
+	if extractScalarValue(arr, 2) != "third" {
+		t.Error("index 2 should be 'third'")
+	}
+}
+
+func TestExtractScalarValue_NestedList(t *testing.T) {
+	alloc := memory.NewGoAllocator()
+
+	// List of lists of int64
+	innerListType := arrow.ListOf(arrow.PrimitiveTypes.Int64)
+	lb := array.NewListBuilder(alloc, innerListType)
+	defer lb.Release()
+
+	innerLb := lb.ValueBuilder().(*array.ListBuilder)
+	innerVb := innerLb.ValueBuilder().(*array.Int64Builder)
+
+	lb.Append(true)
+	innerLb.Append(true)
+	innerVb.Append(1)
+	innerVb.Append(2)
+	innerLb.Append(true)
+	innerVb.Append(3)
+	innerVb.Append(4)
+
+	arr := lb.NewArray()
+	defer arr.Release()
+
+	result := extractScalarValue(arr, 0)
+	v, ok := result.([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", result)
+	}
+	if len(v) != 2 {
+		t.Fatalf("expected 2 inner lists, got %d", len(v))
+	}
+	inner0, ok := v[0].([]any)
+	if !ok || len(inner0) != 2 {
+		t.Errorf("expected inner list with 2 elements, got %v", v[0])
+	}
+	inner1, ok := v[1].([]any)
+	if !ok || len(inner1) != 2 {
+		t.Errorf("expected inner list with 2 elements, got %v", v[1])
+	}
+}

--- a/flight/doexchange_params.go
+++ b/flight/doexchange_params.go
@@ -12,7 +12,7 @@ import (
 // decodeTableFunctionParams extracts function parameters from msgpack-encoded metadata.
 // The metadata contains a map with a "parameters" field that can be in multiple formats:
 // - []byte: msgpack-encoded array
-// - []interface{}: direct array
+// - []any: direct array
 // - string: Arrow IPC-encoded RecordBatch
 func decodeTableFunctionParams(appMetadata []byte, logger *slog.Logger) []any {
 	if len(appMetadata) == 0 {
@@ -42,8 +42,8 @@ func decodeTableFunctionParams(appMetadata []byte, logger *slog.Logger) []any {
 }
 
 // decodeMsgpackMap decodes msgpack-encoded bytes into a map.
-func decodeMsgpackMap(data []byte, logger *slog.Logger) (map[string]interface{}, error) {
-	var paramMap map[string]interface{}
+func decodeMsgpackMap(data []byte, logger *slog.Logger) (map[string]any, error) {
+	var paramMap map[string]any
 	if err := msgpack.Decode(data, &paramMap); err != nil {
 		logger.Warn("Failed to decode parameters as map",
 			"error", err,
@@ -63,11 +63,11 @@ func decodeMsgpackMap(data []byte, logger *slog.Logger) (map[string]interface{},
 }
 
 // extractParameters extracts parameter array from various formats.
-func extractParameters(paramsVal interface{}, logger *slog.Logger) []any {
+func extractParameters(paramsVal any, logger *slog.Logger) []any {
 	switch v := paramsVal.(type) {
 	case []byte:
 		return extractParamsFromBytes(v, logger)
-	case []interface{}:
+	case []any:
 		return extractParamsFromArray(v, logger)
 	case string:
 		return extractParamsFromArrowIPC(v, logger)
@@ -83,7 +83,7 @@ func extractParameters(paramsVal interface{}, logger *slog.Logger) []any {
 func extractParamsFromBytes(paramsBytes []byte, logger *slog.Logger) []any {
 	logger.Debug("Parameters is bytes, attempting msgpack decode", "len", len(paramsBytes))
 
-	var paramArray []interface{}
+	var paramArray []any
 	if err := msgpack.Decode(paramsBytes, &paramArray); err != nil {
 		logger.Warn("Failed to decode parameters bytes as msgpack array", "error", err)
 		return []any{}
@@ -97,7 +97,7 @@ func extractParamsFromBytes(paramsBytes []byte, logger *slog.Logger) []any {
 }
 
 // extractParamsFromArray returns the parameter array directly.
-func extractParamsFromArray(paramsArray []interface{}, logger *slog.Logger) []any {
+func extractParamsFromArray(paramsArray []any, logger *slog.Logger) []any {
 	logger.Debug("Extracted parameters array",
 		"param_count", len(paramsArray),
 		"params", paramsArray,

--- a/flight/getflightinfo.go
+++ b/flight/getflightinfo.go
@@ -78,7 +78,7 @@ func (s *Server) GetFlightInfo(ctx context.Context, desc *flight.FlightDescripto
 	}
 
 	// Generate ticket
-	ticket, err := EncodeTicket(s.CatalogName(), schemaName, tableName)
+	ticket, err := EncodeTableTicket(s.CatalogName(), schemaName, tableName)
 	if err != nil {
 		s.logger.Error("Failed to encode ticket",
 			"schema", schemaName,

--- a/flight/ticket.go
+++ b/flight/ticket.go
@@ -29,7 +29,7 @@ type TicketData struct {
 	// FunctionParams are the parameters for table function execution (optional)
 	// Only valid when TableFunction is set
 	// Parameters are serialized as JSON-compatible values
-	FunctionParams []interface{} `json:"function_params,omitempty"`
+	FunctionParams []any `json:"function_params,omitempty"`
 
 	// TimePointUnit specifies time granularity for time-travel queries (optional)
 	// Valid values: "timestamp", "timestamp_ns", "version", etc.

--- a/flight/ticket.go
+++ b/flight/ticket.go
@@ -28,8 +28,7 @@ type TicketData struct {
 
 	// FunctionParams are the parameters for table function execution (optional)
 	// Only valid when TableFunction is set
-	// Parameters are serialized as JSON-compatible values
-	FunctionParams []any `json:"function_params,omitempty"`
+	FunctionParams []byte `json:"function_params,omitempty"`
 
 	// TimePointUnit specifies time granularity for time-travel queries (optional)
 	// Valid values: "timestamp", "timestamp_ns", "version", etc.
@@ -48,10 +47,10 @@ type TicketData struct {
 	Filters []byte `json:"filters,omitempty"`
 }
 
-// EncodeTicket creates an opaque ticket from schema and table names.
+// EncodeTableTicket creates an opaque ticket from schema and table names.
 // The ticket is JSON-encoded for simplicity and transparency.
 // Returns error if encoding fails.
-func EncodeTicket(catalog, schema, table string) ([]byte, error) {
+func EncodeTableTicket(catalog, schema, table string) ([]byte, error) {
 	if schema == "" {
 		return nil, fmt.Errorf("schema name cannot be empty")
 	}
@@ -111,6 +110,16 @@ func DecodeTicket(ticketBytes []byte) (*TicketData, error) {
 	}
 
 	return &ticket, nil
+}
+
+// Encode serializes TicketData into an opaque ticket byte slice (json).
+// Returns error if encoding fails.
+func (td *TicketData) Encode() ([]byte, error) {
+	data, err := json.Marshal(td)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode ticket data: %w", err)
+	}
+	return data, nil
 }
 
 // ToScanOptions converts TicketData to catalog.ScanOptions with time-travel support.

--- a/flight/ticket_test.go
+++ b/flight/ticket_test.go
@@ -26,7 +26,7 @@ func TestEncodeDecodeTicket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Encode
-			encoded, err := EncodeTicket("", tt.schema, tt.table)
+			encoded, err := EncodeTableTicket("", tt.schema, tt.table)
 			if err != nil {
 				t.Fatalf("EncodeTicket() error = %v", err)
 			}
@@ -247,7 +247,7 @@ func TestEncodeTicketValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := EncodeTicket("", tt.schema, tt.table)
+			_, err := EncodeTableTicket("", tt.schema, tt.table)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("EncodeTicket() error = %v, wantError %v", err, tt.wantError)

--- a/internal/msgpack/decode.go
+++ b/internal/msgpack/decode.go
@@ -21,7 +21,7 @@ import (
 //
 //	var params QueryParams
 //	err := msgpack.Decode(data, &params)
-func Decode(data []byte, v interface{}) error {
+func Decode(data []byte, v any) error {
 	if len(data) == 0 {
 		return fmt.Errorf("empty MessagePack data")
 	}
@@ -43,7 +43,7 @@ func Decode(data []byte, v interface{}) error {
 //	    Table:  "users",
 //	}
 //	data, err := msgpack.Encode(params)
-func Encode(v interface{}) ([]byte, error) {
+func Encode(v any) ([]byte, error) {
 	data, err := msgpack.Marshal(v)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode MessagePack: %w", err)

--- a/specs/001-repo-preparation/contracts/arrow-geometry-metadata.md
+++ b/specs/001-repo-preparation/contracts/arrow-geometry-metadata.md
@@ -396,11 +396,11 @@ func TestDuckDBGeometryIntegration(t *testing.T) {
     require.NoError(t, err)
 
     // Verify geometry metadata in GeoParquet
-    verifyGeoParquetMetadata(t, "test_places.parquet", map[string]interface{}{
+    verifyGeoParquetMetadata(t, "test_places.parquet", map[string]any{
         "version":        "1.1.0",
         "primary_column": "location",
-        "columns": map[string]interface{}{
-            "location": map[string]interface{}{
+        "columns": map[string]any{
+            "location": map[string]any{
                 "encoding":       "WKB",
                 "geometry_types": []string{"Point"},
             },
@@ -458,7 +458,7 @@ func TestGeometryFieldMetadata(t *testing.T) {
 
     // Verify CRS is valid JSON
     extMetadata := field.Metadata.Get("ARROW:extension:metadata")
-    var metadata map[string]interface{}
+    var metadata map[string]any
     err := json.Unmarshal([]byte(extMetadata), &metadata)
     require.NoError(t, err)
 

--- a/specs/001-repo-preparation/quickstart.md
+++ b/specs/001-repo-preparation/quickstart.md
@@ -224,7 +224,7 @@ func (s *Server) handleCreateSchema(body []byte, stream flight.FlightService_DoA
     if existing != nil {
         if action.IfNotExists {
             // Idempotent: return success
-            return s.sendActionResult(stream, map[string]interface{}{
+            return s.sendActionResult(stream, map[string]any{
                 "status":      "success",
                 "schema_name": action.SchemaName,
             })
@@ -236,13 +236,13 @@ func (s *Server) handleCreateSchema(body []byte, stream flight.FlightService_DoA
     // This is a placeholder - actual implementation depends on catalog
     // TODO: Add CreateSchema method to catalog.Catalog interface
 
-    return s.sendActionResult(stream, map[string]interface{}{
+    return s.sendActionResult(stream, map[string]any{
         "status":      "success",
         "schema_name": action.SchemaName,
     })
 }
 
-func (s *Server) sendActionResult(stream flight.FlightService_DoActionServer, data interface{}) error {
+func (s *Server) sendActionResult(stream flight.FlightService_DoActionServer, data any) error {
     jsonData, err := json.Marshal(data)
     if err != nil {
         return status.Errorf(codes.Internal, "failed to marshal result: %v", err)

--- a/specs/002-dml-transactions/contracts/dml-operations.md
+++ b/specs/002-dml-transactions/contracts/dml-operations.md
@@ -237,7 +237,7 @@ func insertRows(ctx context.Context, client flight.FlightServiceClient,
     schema, table string, data arrow.RecordBatch) (int64, error) {
 
     // Build descriptor
-    desc := map[string]interface{}{
+    desc := map[string]any{
         "operation": "insert",
         "schema_name": schema,
         "table_name": table,
@@ -284,7 +284,7 @@ func deleteWithTx(ctx context.Context, client flight.FlightServiceClient,
     // Build action
     action := &flight.Action{
         Type: "delete",
-        Body: mustJSON(map[string]interface{}{
+        Body: mustJSON(map[string]any{
             "schema_name": schema,
             "table_name": table,
             "row_ids": rowIDs,

--- a/specs/002-dml-transactions/quickstart.md
+++ b/specs/002-dml-transactions/quickstart.md
@@ -263,7 +263,7 @@ func insertData(ctx context.Context, addr string) error {
     client := flight.NewFlightServiceClient(conn)
 
     // Build INSERT descriptor
-    desc := map[string]interface{}{
+    desc := map[string]any{
         "operation":   "insert",
         "schema_name": "analytics",
         "table_name":  "events",
@@ -317,7 +317,7 @@ func deleteData(ctx context.Context, addr string, rowIDs []int64) error {
     client := flight.NewFlightServiceClient(conn)
 
     // Build DELETE action
-    body, _ := json.Marshal(map[string]interface{}{
+    body, _ := json.Marshal(map[string]any{
         "schema_name": "analytics",
         "table_name":  "events",
         "row_ids":     rowIDs,

--- a/specs/002-dml-transactions/research.md
+++ b/specs/002-dml-transactions/research.md
@@ -70,7 +70,7 @@ if descriptor.Returning {
     writer.Write(returningBatch)
     writer.Close()
 
-    result := map[string]interface{}{
+    result := map[string]any{
         "status": "success",
         "affected_rows": affectedRows,
         "returning_data": buf.Bytes(),

--- a/tests/integration/datatypes_test.go
+++ b/tests/integration/datatypes_test.go
@@ -280,7 +280,7 @@ func allTypesTestCatalog() catalog.Catalog {
 		{Name: "timestamp_col", Type: arrow.FixedWidthTypes.Timestamp_us},
 	}, nil)
 
-	allTypesData := [][]interface{}{
+	allTypesData := [][]any{
 		{
 			true, int8(127), int16(32767), int32(2147483647), int64(9223372036854775807),
 			uint8(255), uint16(65535), uint32(4294967295), uint64(18446744073709551615),
@@ -351,7 +351,7 @@ func geometryTestCatalog() catalog.Catalog {
 		panic(err)
 	}
 
-	geomData := [][]interface{}{
+	geomData := [][]any{
 		{int64(1), pointWKB},
 		{int64(2), linestringWKB},
 		{int64(3), polygonWKB},
@@ -391,7 +391,7 @@ func uuidTestCatalog() catalog.Catalog {
 		0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00, 0x00,
 	}
 
-	uuidData := [][]interface{}{
+	uuidData := [][]any{
 		{int64(1), uuidBytes},
 	}
 
@@ -423,7 +423,7 @@ func jsonTestCatalog() catalog.Catalog {
 		})},
 	}, nil)
 
-	jsonData := [][]interface{}{
+	jsonData := [][]any{
 		{int64(1), `{"name": "Alice", "age": 30, "city": "NYC"}`},
 		{int64(2), `{"name": "Bob", "age": 25, "city": "LA"}`},
 	}
@@ -475,7 +475,7 @@ func hugeintTestCatalog() catalog.Catalog {
 		uhugeBytes[i] = 0x00
 	}
 
-	hugeintData := [][]interface{}{
+	hugeintData := [][]any{
 		{int64(1), hugeBytes, uhugeBytes},
 	}
 

--- a/tests/integration/discovery_test.go
+++ b/tests/integration/discovery_test.go
@@ -43,7 +43,7 @@ func TestListSchemas(t *testing.T) {
 
 	// Parse compressed response (Airport format)
 	// AirportSerializedCompressedContent is encoded as ARRAY: [length, data]
-	var compressedContent []interface{}
+	var compressedContent []any
 	if err := msgpack.Decode(result.Body, &compressedContent); err != nil {
 		t.Fatalf("failed to decode compressed content: %v", err)
 	}

--- a/tests/integration/dml_batch_test.go
+++ b/tests/integration/dml_batch_test.go
@@ -410,10 +410,10 @@ func (t *batchDMLTable) Scan(ctx context.Context, opts *catalog.ScanOptions) (ar
 	return array.NewRecordReader(t.schema, []arrow.RecordBatch{record})
 }
 
-func (t *batchDMLTable) convertData() [][]interface{} {
-	result := make([][]interface{}, len(t.data))
+func (t *batchDMLTable) convertData() [][]any {
+	result := make([][]any, len(t.data))
 	for i, row := range t.data {
-		result[i] = make([]interface{}, len(row))
+		result[i] = make([]any, len(row))
 		copy(result[i], row)
 	}
 	return result

--- a/tests/integration/dml_test.go
+++ b/tests/integration/dml_test.go
@@ -1464,10 +1464,10 @@ func (t *duckDBDMLTable) Scan(ctx context.Context, opts *catalog.ScanOptions) (a
 	return array.NewRecordReader(t.schema, []arrow.RecordBatch{record})
 }
 
-func (t *duckDBDMLTable) convertData() [][]interface{} {
-	result := make([][]interface{}, len(t.data))
+func (t *duckDBDMLTable) convertData() [][]any {
+	result := make([][]any, len(t.data))
 	for i, row := range t.data {
-		result[i] = make([]interface{}, len(row))
+		result[i] = make([]any, len(row))
 		copy(result[i], row)
 	}
 	return result

--- a/tests/integration/dynamic_test.go
+++ b/tests/integration/dynamic_test.go
@@ -133,7 +133,7 @@ type liveTable struct {
 	name    string
 	comment string
 	schema  *arrow.Schema
-	getData func() [][]interface{}
+	getData func() [][]any
 }
 
 func (t *liveTable) Name() string {
@@ -241,11 +241,11 @@ func TestLiveData(t *testing.T) {
 		name:    "metrics",
 		comment: "Live metrics",
 		schema:  metricsSchema,
-		getData: func() [][]interface{} {
+		getData: func() [][]any {
 			counterMu.Lock()
 			defer counterMu.Unlock()
 			counter++
-			return [][]interface{}{
+			return [][]any{
 				{"scan_count", int64(counter)},
 			}
 		},
@@ -326,7 +326,7 @@ func TestDynamicTables(t *testing.T) {
 			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
 		}, nil)
 
-		testData := [][]interface{}{{int64(1)}}
+		testData := [][]any{{int64(1)}}
 
 		newTable := catalog.NewStaticTable(
 			"test_table",
@@ -360,7 +360,7 @@ func TestConcurrentCatalogAccess(t *testing.T) {
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
 	}, nil)
 
-	testData := [][]interface{}{{int64(1)}}
+	testData := [][]any{{int64(1)}}
 
 	table := catalog.NewStaticTable(
 		"test",

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -150,7 +150,7 @@ func simpleCatalog() catalog.Catalog {
 		{Name: "email", Type: arrow.BinaryTypes.String},
 	}, nil)
 
-	usersData := [][]interface{}{
+	usersData := [][]any{
 		{int64(1), "Alice", "alice@example.com"},
 		{int64(2), "Bob", "bob@example.com"},
 		{int64(3), "Charlie", "charlie@example.com"},
@@ -163,7 +163,7 @@ func simpleCatalog() catalog.Catalog {
 		{Name: "price", Type: arrow.PrimitiveTypes.Float64},
 	}, nil)
 
-	productsData := [][]interface{}{
+	productsData := [][]any{
 		{int64(101), "Widget", 9.99},
 		{int64(102), "Gadget", 19.99},
 		{int64(103), "Doohickey", 29.99},
@@ -202,7 +202,7 @@ func authenticatedCatalog() catalog.Catalog {
 		{Name: "value", Type: arrow.BinaryTypes.String},
 	}, nil)
 
-	secretsData := [][]interface{}{
+	secretsData := [][]any{
 		{"api_key", "secret123"},
 		{"db_password", "pass456"},
 	}
@@ -242,7 +242,7 @@ func testAuthHandler() airport.Authenticator {
 }
 
 // buildTestRecord creates an Arrow record from test data.
-func buildTestRecord(schema *arrow.Schema, data [][]interface{}) arrow.RecordBatch {
+func buildTestRecord(schema *arrow.Schema, data [][]any) arrow.RecordBatch {
 	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
 	defer builder.Release()
 
@@ -293,7 +293,7 @@ func buildTestRecord(schema *arrow.Schema, data [][]interface{}) arrow.RecordBat
 }
 
 // makeScanFunc creates a ScanFunc from in-memory data.
-func makeScanFunc(schema *arrow.Schema, data [][]interface{}) catalog.ScanFunc {
+func makeScanFunc(schema *arrow.Schema, data [][]any) catalog.ScanFunc {
 	return func(ctx context.Context, opts *catalog.ScanOptions) (array.RecordReader, error) {
 		record := buildTestRecord(schema, data)
 		defer record.Release()

--- a/tests/integration/query_test.go
+++ b/tests/integration/query_test.go
@@ -345,8 +345,8 @@ type timeTravelTable struct {
 	comment  string
 	schemaV1 *arrow.Schema
 	schemaV2 *arrow.Schema
-	dataV1   [][]interface{}
-	dataV2   [][]interface{}
+	dataV1   [][]any
+	dataV2   [][]any
 	time2    time.Time
 }
 
@@ -377,7 +377,7 @@ func (t *timeTravelTable) SchemaForRequest(ctx context.Context, req *catalog.Sch
 func (t *timeTravelTable) Scan(ctx context.Context, opts *catalog.ScanOptions) (array.RecordReader, error) {
 	// Determine which version to return based on timestamp
 	var schema *arrow.Schema
-	var data [][]interface{}
+	var data [][]any
 
 	if opts.TimePoint != nil {
 		requestTime := t.parseTimePoint(opts.TimePoint)
@@ -448,14 +448,14 @@ func timeTravelCatalog() catalog.Catalog {
 	}, nil)
 
 	// Data at time1 (3 users, no phone column)
-	dataV1 := [][]interface{}{
+	dataV1 := [][]any{
 		{int64(1), "Alice", "alice@example.com"},
 		{int64(2), "Bob", "bob@example.com"},
 		{int64(3), "Charlie", "charlie@example.com"},
 	}
 
 	// Data at time2 (4 users, with phone column)
-	dataV2 := [][]interface{}{
+	dataV2 := [][]any{
 		{int64(1), "Alice", "alice@example.com", "555-0001"},
 		{int64(2), "Bob", "bob@updated.com", "555-0002"}, // Email updated
 		{int64(3), "Charlie", "charlie@example.com", "555-0003"},

--- a/tests/integration/scalar_functions_test.go
+++ b/tests/integration/scalar_functions_test.go
@@ -280,7 +280,7 @@ func TestFunctionErrors(t *testing.T) {
 			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
 		}, nil)
 
-		testData := [][]interface{}{{int64(1)}, {int64(2)}, {int64(3)}}
+		testData := [][]any{{int64(1)}, {int64(2)}, {int64(3)}}
 
 		cat, err := airport.NewCatalogBuilder().
 			Schema("some_schema").
@@ -344,7 +344,7 @@ func TestTypeMismatch(t *testing.T) {
 			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
 		}, nil)
 
-		testData := [][]interface{}{{int64(1)}, {int64(2)}}
+		testData := [][]any{{int64(1)}, {int64(2)}}
 
 		cat, err := airport.NewCatalogBuilder().
 			Schema("some_schema").
@@ -396,7 +396,7 @@ func TestTypeMismatch(t *testing.T) {
 
 // TestScalarFunctionDataTypes tests scalar functions with different Arrow data types.
 func TestScalarFunctionDataTypes(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{int64(10), int64(5), 2.5, 3.0, "hello", "world"},
 		{int64(-5), int64(3), 1.5, 2.0, "foo", "bar"},
 		{int64(0), int64(0), 0.0, 0.0, "test", "case"},
@@ -1124,7 +1124,7 @@ func catalogWithScalarFunctions() catalog.Catalog {
 		{Name: "name", Type: arrow.BinaryTypes.String},
 	}, nil)
 
-	usersData := [][]interface{}{
+	usersData := [][]any{
 		{int64(1), "alice"},
 		{int64(2), "bob"},
 		{int64(3), "charlie"},

--- a/tests/integration/transaction_test.go
+++ b/tests/integration/transaction_test.go
@@ -147,7 +147,7 @@ func TestCreateTransaction(t *testing.T) {
 	ctx := context.Background()
 
 	// Create request body
-	requestBody, err := msgpack.Encode(map[string]interface{}{
+	requestBody, err := msgpack.Encode(map[string]any{
 		"catalog_name": "",
 	})
 	if err != nil {
@@ -208,7 +208,7 @@ func TestGetTransactionStatus(t *testing.T) {
 	}
 
 	// Create request body
-	requestBody, err := msgpack.Encode(map[string]interface{}{
+	requestBody, err := msgpack.Encode(map[string]any{
 		"transaction_id": txID,
 	})
 	if err != nil {
@@ -258,7 +258,7 @@ func TestGetTransactionStatusNotFound(t *testing.T) {
 	ctx := context.Background()
 
 	// Create request body with non-existent transaction ID
-	requestBody, err := msgpack.Encode(map[string]interface{}{
+	requestBody, err := msgpack.Encode(map[string]any{
 		"transaction_id": "non-existent-tx-id",
 	})
 	if err != nil {
@@ -339,7 +339,7 @@ func TestTransactionWithoutManager(t *testing.T) {
 	ctx := context.Background()
 
 	// Create request body
-	requestBody, err := msgpack.Encode(map[string]interface{}{
+	requestBody, err := msgpack.Encode(map[string]any{
 		"catalog_name": "",
 	})
 	if err != nil {
@@ -385,7 +385,7 @@ func TestDMLWithTransaction(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a transaction first
-	createReq, _ := msgpack.Encode(map[string]interface{}{"catalog_name": ""})
+	createReq, _ := msgpack.Encode(map[string]any{"catalog_name": ""})
 	createAction := &flight.Action{Type: "create_transaction", Body: createReq}
 
 	stream, err := env.client.DoAction(ctx, createAction)


### PR DESCRIPTION
Enhanced the extractScalarValue function to support additional Arrow data types including Date, Timestamp, Time, Decimal, List, Struct, and Map.

Refactor code to use 'any' type instead of 'interface{}' for improved type safety and clarity

- Updated various functions and methods across multiple files to replace instances of 'interface{}' with 'any'.
- Modified the handling of app metadata, transaction responses, and parameter extraction to utilize the new type.
- Added comprehensive unit tests for extractScalarValue to ensure correct handling of various data types.
- Adjusted integration tests and quickstart examples to align with the new type usage.

Closes #20